### PR TITLE
NewGardenBottomSheet crash fix

### DIFF
--- a/app/src/main/java/com/carbonara/gardenadvisor/ui/dialog/newgarden/NewGardenBottomSheet.java
+++ b/app/src/main/java/com/carbonara/gardenadvisor/ui/dialog/newgarden/NewGardenBottomSheet.java
@@ -94,6 +94,9 @@ public class NewGardenBottomSheet extends BottomSheetDialogFragment {
                                       binding.tfGardenLocation.setHint("Location found");
                                       binding.tfGardenLocation.setBoxStrokeColor(
                                           ContextCompat.getColor(getContext(), R.color.green));
+
+                                      // when the location is found, cancel the timer
+                                      if (timer != null) timer.cancel();
                                     } else {
                                       binding.tfGardenLocation.setError("No location found");
                                     }


### PR DESCRIPTION
In order to prevent a crash, when the location is found when adding a new garden, make sure the timer is canceled.


```
java.lang.IllegalStateException: Fragment NewGardenBottomSheet{56f2fd5} (b92307e4-8a2b-4b0b-a920-ad89a2eb330e) not attached to an activity.
                                                                                                    	at androidx.fragment.app.Fragment.requireActivity(Fragment.java:1000)
                                                                                                    	at com.carbonara.gardenadvisor.ui.dialog.newgarden.NewGardenBottomSheet$1$1.run(NewGardenBottomSheet.java:80)
                                                                                                    	at java.util.TimerThread.mainLoop(Timer.java:563)
                                                                                                    	at java.util.TimerThread.run(Timer.java:513)
```