### PR TITLE
Add GeminiGardenCameraTask and update prompt

### DIFF
--- a/app/src/main/java/com/carbonara/gardenadvisor/ai/dto/GardeningItem.java
+++ b/app/src/main/java/com/carbonara/gardenadvisor/ai/dto/GardeningItem.java
@@ -19,7 +19,7 @@ import lombok.extern.jackson.Jacksonized;
 @ToString
 @Builder
 @Jacksonized
-public class GardeningItem {
+public class GardeningItem implements GeminiResult {
 
   @JsonInclude(Include.NON_NULL)
   private Long id;

--- a/app/src/main/java/com/carbonara/gardenadvisor/ai/prompt/ConstPrompt.java
+++ b/app/src/main/java/com/carbonara/gardenadvisor/ai/prompt/ConstPrompt.java
@@ -144,4 +144,21 @@ public class ConstPrompt {
           + "\n"
           + "if you can't recognize the plant or the picture does not contain a plant, return an empty string.\n"
           + PLAIN_TEXT_NOTICE;
+
+  public static final String CAMERA_GARDEN_PROMPT =
+      "Given this location and weather data\n"
+          + "if you can recognize the plant in the picture, provide the result in the following json format:\n"
+          + "    {\n"
+          + "      \"name\" : string containing the common name of the plant\n"
+          + "      \"type\": string containing the values flower, fruit or vegetable depending on the type of plant,\n"
+          + "      \"recommended\": true if is recommended to plant in this location else false,\n"
+          + "      \"recommendedScore\": integer value from 1 to 5 of how recommended it is to plant,\n"
+          + "      \"maintenanceScore\": integer value from 1 to 5 of how easy it is to maintain,\n"
+          + "      \"positives\": a list of the positive factors of the weather data\n"
+          + "      \"cautions\": a list of what i need to be careful when planting\n"
+          + "      \"suggestions\": a list of possible improvements to get a better result given some suggestions\n"
+          + "}"
+          + "\n"
+          + "if you can't recognize the plant or the picture does not contain a plant, return an empty string.\n"
+          + PLAIN_TEXT_NOTICE;
 }

--- a/app/src/main/java/com/carbonara/gardenadvisor/ai/task/impl/GeminiGardenCameraTask.java
+++ b/app/src/main/java/com/carbonara/gardenadvisor/ai/task/impl/GeminiGardenCameraTask.java
@@ -1,0 +1,61 @@
+package com.carbonara.gardenadvisor.ai.task.impl;
+
+import static com.carbonara.gardenadvisor.ai.prompt.ConstPrompt.CAMERA_GARDEN_PROMPT;
+import static com.carbonara.gardenadvisor.util.ApiKeyUtility.getGeminiApiKey;
+import static com.carbonara.gardenadvisor.util.LogUtil.loge;
+
+import android.graphics.Bitmap;
+import com.carbonara.gardenadvisor.ai.dto.GardeningItem;
+import com.carbonara.gardenadvisor.ai.task.GeminiSingleOnSubscriber;
+import com.carbonara.gardenadvisor.ai.task.GeminiTask;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.ai.client.generativeai.GenerativeModel;
+import com.google.ai.client.generativeai.java.GenerativeModelFutures;
+import com.google.ai.client.generativeai.type.Content;
+import com.google.ai.client.generativeai.type.GenerateContentResponse;
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.reactivex.rxjava3.core.SingleEmitter;
+import java.io.IOException;
+
+public class GeminiGardenCameraTask extends GeminiTask
+    implements GeminiSingleOnSubscriber<GardeningItem> {
+
+  private final Bitmap pictureTaken;
+
+  public GeminiGardenCameraTask(float lat, float lon, String locationName, Bitmap pictureTaken) {
+    super(lat, lon, locationName);
+    this.pictureTaken = pictureTaken;
+  }
+
+  @Override
+  public void subscribe(@NonNull SingleEmitter<GardeningItem> emitter) throws Throwable {
+    GenerativeModel gm = new GenerativeModel("gemini-1.5-flash", getGeminiApiKey());
+    GenerativeModelFutures model = GenerativeModelFutures.from(gm);
+    Content content =
+        new Content.Builder().addImage(pictureTaken).addText(getPrompt(weatherData())).build();
+    GenerateContentResponse response = model.generateContent(content).get();
+
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+    try {
+      GardeningItem gardeningItem = mapper.readValue(response.getText(), GardeningItem.class);
+
+      if (!emitter.isDisposed()) {
+        emitter.onSuccess(gardeningItem);
+      }
+
+    } catch (IOException e) {
+      loge("Could not get camera suggestions for garden", e);
+
+      if (!emitter.isDisposed()) {
+        emitter.onError(e);
+      }
+    }
+  }
+
+  @Override
+  public String getPrompt(String weather) {
+    return weather + "\nLocation Name: " + getLocationName() + "\n" + CAMERA_GARDEN_PROMPT;
+  }
+}


### PR DESCRIPTION
Adding a GeminiGardenCameraTask which can be used to return a GardeningItem in a garden.
Being an implementation of GeminiSingleOnSubscriber it supports lat, lon, location name handling as well as weather.
A new prompt was added in order to work on the provided picture.

Tested on AI Studio with example result:
```
{
    "name": "Tomato",
    "type": "vegetable",
    "recommended": true,
    "recommendedScore": 5,
    "maintenanceScore": 3,
    "positives":
    [
        "Warm soil temperatures consistently above 18°C",
        "Sunny days for most of the forecast period",
        "No frost expected"
    ],
    "cautions":
    [
        "Periods of high humidity and potential rain could increase disease risk (especially May 29th)",
        "Windy conditions on May 21st and 22nd could damage young plants"
    ],
    "suggestions":
    [
        "Consider using a cloche or protective cover for seedlings during windy days",
        "Monitor for signs of disease and apply appropriate treatments if needed",
        "Ensure good soil drainage to prevent root rot from excess moisture"
    ]
}
``` 